### PR TITLE
Added missing function definitions to header

### DIFF
--- a/softuart/include/softuart.h
+++ b/softuart/include/softuart.h
@@ -38,6 +38,9 @@ void Softuart_SetPinRx(Softuart *s, uint8_t gpio_id);
 void Softuart_SetPinTx(Softuart *s, uint8_t gpio_id);
 void Softuart_EnableRs485(Softuart *s, uint8_t gpio_id);
 void Softuart_Init(Softuart *s, uint32_t baudrate);
+void Softuart_Putchar(Softuart *s, char data);
+void Softuart_Puts(Softuart *s, const char *c );
+uint8_t Softuart_Readline(Softuart *s, char* Buffer, uint8_t MaxLen );
 
 //define mapping from pin to functio mode
 typedef struct {

--- a/softuart/include/softuart.h
+++ b/softuart/include/softuart.h
@@ -34,7 +34,10 @@ typedef struct {
 
 BOOL Softuart_Available(Softuart *s);
 void Softuart_Intr_Handler(Softuart *s);
-
+void Softuart_SetPinRx(Softuart *s, uint8_t gpio_id);
+void Softuart_SetPinTx(Softuart *s, uint8_t gpio_id);
+void Softuart_EnableRs485(Softuart *s, uint8_t gpio_id);
+void Softuart_Init(Softuart *s, uint32_t baudrate);
 
 //define mapping from pin to functio mode
 typedef struct {


### PR DESCRIPTION
Here is the missing functions in the header file. Mentioned in issue #11 
